### PR TITLE
37-typescript-for-fields-block-model

### DIFF
--- a/src/BlockBuilder.ts
+++ b/src/BlockBuilder.ts
@@ -1,12 +1,12 @@
+import type * as SimpleSchemaTypes from "@datocms/cma-client/src/generated/SimpleSchemaTypes";
 import ItemTypeBuilder, {
   type ItemTypeBuilderType,
 } from "./ItemTypeBuilder.js";
 import type { ResolvedDatoBuilderConfig } from "./types/DatoBuilderConfig.js";
-import type { ItemTypeCreateSchema } from "./types/ItemTypeBuilderTypes";
 
 type BlockBuilderBody = Pick<
-  ItemTypeCreateSchema,
-  "presentation_title_field" | "presentation_image_field"
+  SimpleSchemaTypes.ItemTypeCreateSchema,
+  "hint" | "presentation_title_field" | "presentation_image_field"
 > & {
   /**
    * API key of the block.

--- a/src/BlockBuilder.ts
+++ b/src/BlockBuilder.ts
@@ -2,18 +2,18 @@ import ItemTypeBuilder, {
   type ItemTypeBuilderType,
 } from "./ItemTypeBuilder.js";
 import type { ResolvedDatoBuilderConfig } from "./types/DatoBuilderConfig.js";
+import type { ItemTypeCreateSchema } from "./types/ItemTypeBuilderTypes";
 
-type BlockBuilderBody = {
+type BlockBuilderBody = Pick<
+  ItemTypeCreateSchema,
+  "presentation_title_field" | "presentation_image_field"
+> & {
   /**
    * API key of the block.
    *
    * If not provided, it will be generated from the name.
    */
   api_key?: string;
-  /**
-   * A hint shown to editors to help them understand the purpose of this block.
-   */
-  hint?: string | null;
 };
 
 type BlockBuilderOptions = {

--- a/src/ModelBuilder.ts
+++ b/src/ModelBuilder.ts
@@ -26,7 +26,7 @@ type ModelBuilderBody = Pick<
   | "excerpt_field"
 > & {
   /**
-   * API key of the block.
+   * API key of the model.
    *
    * If not provided, it will be generated from the name.
    */
@@ -35,17 +35,42 @@ type ModelBuilderBody = Pick<
 
 type ModelBuilderOptions = {
   name: string;
+  options?: ModelBuilderBody;
+  config: ResolvedDatoBuilderConfig;
+};
+
+/**
+ * @deprecated Use ModelBuilderOptions with 'options' property instead of 'body'
+ */
+type LegacyModelBuilderOptions = {
+  name: string;
+  /** @deprecated Use 'options' instead */
   body?: ModelBuilderBody;
   config: ResolvedDatoBuilderConfig;
 };
 
+// Union type to support both current and legacy options
+type AllModelBuilderOptions = ModelBuilderOptions | LegacyModelBuilderOptions;
+
 export default class ModelBuilder extends ItemTypeBuilder {
   public override type: ItemTypeBuilderType = "model";
 
-  constructor({ name, body, config }: ModelBuilderOptions) {
+  constructor(params: AllModelBuilderOptions) {
+    const { name, config } = params;
+
+    // Handle both new 'options' and legacy 'body' properties
+    let modelOptions: ModelBuilderBody | undefined;
+
+    if ("options" in params) {
+      modelOptions = params.options;
+    } else if ("body" in params) {
+      // Legacy support
+      modelOptions = params.body;
+    }
+
     super({
       type: "model",
-      body: { ...body, name },
+      body: { ...modelOptions, name },
       config,
     });
   }

--- a/src/ModelBuilder.ts
+++ b/src/ModelBuilder.ts
@@ -1,12 +1,41 @@
+import type * as SimpleSchemaTypes from "@datocms/cma-client/src/generated/SimpleSchemaTypes";
 import ItemTypeBuilder, {
-  type ItemTypeBuilderBody,
   type ItemTypeBuilderType,
 } from "./ItemTypeBuilder.js";
 import type { ResolvedDatoBuilderConfig } from "./types/DatoBuilderConfig.js";
 
+type ModelBuilderBody = Pick<
+  SimpleSchemaTypes.ItemTypeCreateSchema,
+  | "hint"
+  | "tree"
+  | "sortable"
+  | "singleton"
+  | "draft_mode_active"
+  | "draft_saving_active"
+  | "all_locales_required"
+  | "workflow"
+  | "inverse_relationships_enabled"
+  | "collection_appearance"
+  | "ordering_meta"
+  | "ordering_direction"
+  | "ordering_field"
+  | "presentation_title_field"
+  | "presentation_image_field"
+  | "title_field"
+  | "image_preview_field"
+  | "excerpt_field"
+> & {
+  /**
+   * API key of the block.
+   *
+   * If not provided, it will be generated from the name.
+   */
+  api_key?: string;
+};
+
 type ModelBuilderOptions = {
   name: string;
-  body?: Omit<ItemTypeBuilderBody, "name">;
+  body?: ModelBuilderBody;
   config: ResolvedDatoBuilderConfig;
 };
 


### PR DESCRIPTION
Should properly type fields inside Block also, for instance we cannot use `localized` in block (or unique validator, etc...)